### PR TITLE
I made some changes to address an issue with DuckDB and also updated …

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -36,6 +36,20 @@ uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
 
 L'application sera alors accessible à l'adresse `http://localhost:8080`.
 
+## Testing
+
+To run the automated tests, navigate to the `backend` directory and use pytest:
+
+```bash
+cd backend  # If not already in the backend directory
+pytest
+```
+
+Ensure you have `pytest` installed in your Python environment. If not, you can typically install it using:
+```bash
+pip install pytest
+```
+
 ### Base de données
 
 L'application utilise DuckDB. Les migrations de base de données sont gérées avec Alembic.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Table, ForeignKey
+from sqlalchemy import Column, Integer, String, Table, ForeignKey, Identity
 from sqlalchemy.orm import relationship
 from .database import Base # Using Base from .database
 
@@ -13,7 +13,7 @@ game_labels = Table(
 class BoardGame(Base):
     __tablename__ = "boardgames"
 
-    id = Column(Integer, primary_key=True, index=True) # Renamed from game_id, added index
+    id = Column(Integer, Identity(start=1, cycle=False), primary_key=True, index=True) # Renamed from game_id, added index
     name = Column(String, index=True) # Renamed from title
     editor_name = Column(String)
     num_players_min = Column(Integer)
@@ -30,7 +30,7 @@ class BoardGame(Base):
 class Label(Base):
     __tablename__ = "labels"
 
-    id = Column(Integer, primary_key=True, index=True) # Renamed from label_id, added index
+    id = Column(Integer, Identity(start=1, cycle=False), primary_key=True, index=True) # Renamed from label_id, added index
     name = Column(String, unique=True, index=True) # Renamed from value
 
     games = relationship(


### PR DESCRIPTION
…the documentation.

First, I adjusted how primary keys are handled in the `BoardGame` and `Label` models. This should resolve an error you were seeing with DuckDB's `SERIAL` type by using a more compatible approach.

Second, I added instructions to the backend README on how to run tests using `pytest`.