### PR TITLE
Fix: Add CORS middleware to allow requests from frontend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 import os
 from fastapi import Depends, FastAPI, HTTPException # Added HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from typing import List
 from sqlalchemy.orm import Session
 from . import crud, models, schemas # models.Base will be accessed via this
@@ -10,6 +11,15 @@ from .database import SessionLocal, engine # engine is here
 # models.Base.metadata.create_all(bind=engine) # Commented out to prevent execution during test collection
 
 app = FastAPI()
+
+# CORS Middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],  # Allows specific origin
+    allow_credentials=True,
+    allow_methods=["*"],  # Allows all methods
+    allow_headers=["*"],  # Allows all headers
+)
 
 # Dependency
 def get_db():


### PR DESCRIPTION
The frontend application, running on http://localhost:3000, was unable to access the API at http://localhost:8080/api/boardgames due to missing CORS headers.

This commit adds the FastAPI CORSMiddleware to your backend application. The middleware is configured to allow all origins, methods, and headers from http://localhost:3000, resolving the CORS issue.